### PR TITLE
FIX: object x not found error in testApp

### DIFF
--- a/09_DevelopingDataProducts/shiny2/testApp/server.R
+++ b/09_DevelopingDataProducts/shiny2/testApp/server.R
@@ -1,4 +1,5 @@
 library(shiny)
+x <<- 0
 x <<- x + 1
 y <<- 0
 


### PR DESCRIPTION
The following error is raised when running runApp(): "Error in eval(expr, envir, enclos) : object 'x' not found"

This pull request fixes that error assigning an initial value to 'x'. After watching the lecture video, I think this should be the initial state of the testApp.
