### PR TITLE
Fixed prediction command for splines on the test set

### DIFF
--- a/08_PracticalMachineLearning/015covariateCreation/index.Rmd
+++ b/08_PracticalMachineLearning/015covariateCreation/index.Rmd
@@ -139,7 +139,7 @@ points(training$age,predict(lm1,newdata=training),col="red",pch=19,cex=0.5)
 ## Splines on the test set
 
 ```{r ,dependson="splines",fig.height=4,fig.width=4}
-predict(bsBasis,age=testing$age)
+predict(bsBasis,newx=testing$age)
 ```
 
 


### PR DESCRIPTION
This change addresses a little typo in the function to predict on the test set.  Because "age" isn't a valid argument for predict.bs, the command "predict(bsBasis,age=testing$age)" just re-outputs the splines that were already generated on the training set.

The corresponding HTML and .md files will need to be regenerated after this change.  I considered including them in another commit, but it made the diffs crazy and I thought it would just confuse the issue.