### PR TITLE
Update index.Rmd

### DIFF
--- a/09_DevelopingDataProducts/slidify/index.Rmd
+++ b/09_DevelopingDataProducts/slidify/index.Rmd
@@ -42,8 +42,8 @@ library(devtools)
 - Second, install Slidify
 
 ```r
-install_github('slidify', 'ramnathv')
-install_github('slidifyLibraries', 'ramnathv')
+install_github('ramnathv/slidify')
+install_github('ramnathv/slidifyLibraries')
 ```
 
 - Third, load Slidify


### PR DESCRIPTION
devtools install_github username parameter is deprecated. Updated install command to current syntax.