### PR TITLE
Fixing typos

### DIFF
--- a/02_RProgramming/DataTypes/index.Rmd
+++ b/02_RProgramming/DataTypes/index.Rmd
@@ -322,7 +322,7 @@ no yes
  2   3
 > unclass(x)
 [1] 2 2 1 2 1
-attr(,"levels")
+attr(x,"levels")
 [1] "no"  "yes"
 ```
 

--- a/02_RProgramming/DataTypes/index.html
+++ b/02_RProgramming/DataTypes/index.html
@@ -415,7 +415,7 @@ no yes
  2   3
 &gt; unclass(x)
 [1] 2 2 1 2 1
-attr(,&quot;levels&quot;)
+attr(x,&quot;levels&quot;)
 [1] &quot;no&quot;  &quot;yes&quot;
 </code></pre>
 

--- a/02_RProgramming/DataTypes/index.md
+++ b/02_RProgramming/DataTypes/index.md
@@ -322,7 +322,7 @@ no yes
  2   3
 > unclass(x)
 [1] 2 2 1 2 1
-attr(,"levels")
+attr(x,"levels")
 [1] "no"  "yes"
 ```
 

--- a/02_RProgramming/syllabus.md
+++ b/02_RProgramming/syllabus.md
@@ -115,7 +115,7 @@ Johns Hopkins University defines plagiarism as "...taking for one's own use the 
 
 We recognize that many students may not have a clear understanding of what plagiarism is or why it is wrong. Please see the following guide for more information on plagiarism:
 
-[http://www.jhsph.edu/academics/degree-programs/master-of-public-health/current-students/JHSPH-Refere...](http://www.jhsph.edu/academics/degree-programs/master-of-public-health/current-students/JHSPH-ReferencingHandbook.pdf)
+[JSHPH Student Handbook on Referencing](http://www.jhsph.edu/academics/degree-programs/master-of-public-health/current-students/JHSPH-StudentReferencing_handbook.pdf)
 
 It is critically important that you give people/sources credit when you use their words or ideas. If you do not give proper credit -- particularly when quoting directly from a source -- you violate the trust of your fellow students.
 

--- a/03_GettingData/01_07_readingXML/index.md
+++ b/03_GettingData/01_07_readingXML/index.md
@@ -117,7 +117,7 @@ rootNode[[1]][[1]]
 
 ---
 
-## Programatically extract parts of the file
+## Programmatically extract parts of the file
 
 
 ```r

--- a/03_GettingData/01_08_readingJSON/index.md
+++ b/03_GettingData/01_08_readingJSON/index.md
@@ -31,7 +31,7 @@ mode        : selfcontained # {standalone, draft}
   * Strings (double quoted)
   * Boolean (_true_ or _false_)
   * Array (ordered, comma separated enclosed in square brackets _[]_)
-  * Object (unorderd, comma separated collection of key:value pairs in curley brackets _{}_)
+  * Object (unordered, comma separated collection of key:value pairs in curly brackets _{}_)
 
 
 [http://en.wikipedia.org/wiki/JSON](http://en.wikipedia.org/wiki/JSON)

--- a/03_GettingData/01_09_dataTable/index.md
+++ b/03_GettingData/01_09_dataTable/index.md
@@ -20,7 +20,7 @@ mode        : selfcontained # {standalone, draft}
 
 ## data.table
 
-* Inherets from data.frame
+* Inherits from data.frame
   * All functions that accept data.frame work on data.table
 * Written in C so it is much faster
 * Much, much faster at subsetting, group, and updating
@@ -138,7 +138,7 @@ DT[,c(2,3)]
 
 * The subsetting function is modified for data.table
 * The argument you pass after the comma is called an "expression"
-* In R an expression is a collection of statements enclosed in curley brackets 
+* In R an expression is a collection of statements enclosed in curly brackets 
 
 ```r
 {

--- a/03_GettingData/02_01_readingMySQL/index.md
+++ b/03_GettingData/02_01_readingMySQL/index.md
@@ -441,7 +441,7 @@ dbDisconnect(hg19)
 
 * RMySQL vignette [http://cran.r-project.org/web/packages/RMySQL/RMySQL.pdf](http://cran.r-project.org/web/packages/RMySQL/RMySQL.pdf)
 * List of commands [http://www.pantz.org/software/mysql/mysqlcommands.html](http://www.pantz.org/software/mysql/mysqlcommands.html)
-  * __Do not, do not, delete, add or join things from ensembl. Only select.__
-  * In general be careful with mysql commands
+  * __Do not, do not, delete, add or join things from ensemble. Only select.__
+  * In general be careful with MySQL commands
 * A nice blog post summarizing some other commands [http://www.r-bloggers.com/mysql-and-r/](http://www.r-bloggers.com/mysql-and-r/)
   

--- a/03_GettingData/02_02_readingHDF5/index.md
+++ b/03_GettingData/02_02_readingHDF5/index.md
@@ -23,7 +23,7 @@ mode        : selfcontained # {standalone, draft}
 
 * Used for storing large data sets
 * Supports storing a range of data types
-* Heirarchical data format
+* Hierarchical data format
 * _groups_ containing zero or more data sets and metadata
   * Have a _group header_ with group name and list of attributes
   * Have a _group symbol table_ with a list of objects in group
@@ -182,4 +182,4 @@ h5read("example.h5","foo/A")
 * hdf5 can be used to optimize reading/writing from disc in R
 * The rhdf5 tutorial: 
   * [http://www.bioconductor.org/packages/release/bioc/vignettes/rhdf5/inst/doc/rhdf5.pdf](http://www.bioconductor.org/packages/release/bioc/vignettes/rhdf5/inst/doc/rhdf5.pdf)
-* The HDF group has informaton on HDF5 in general [http://www.hdfgroup.org/HDF5/](http://www.hdfgroup.org/HDF5/)
+* The HDF group has information on HDF5 in general [http://www.hdfgroup.org/HDF5/](http://www.hdfgroup.org/HDF5/)

--- a/03_GettingData/02_03_readingFromTheWeb/index.md
+++ b/03_GettingData/02_03_readingFromTheWeb/index.md
@@ -21,10 +21,10 @@ mode        : selfcontained # {standalone, draft}
 
 ## Webscraping
 
-__Webscraping__: Programatically extracting data from the HTML code of websites. 
+__Webscraping__: Programmatically extracting data from the HTML code of websites. 
 
 * It can be a great way to get data [How Netflix reverse engineered Hollywood](http://www.theatlantic.com/technology/archive/2014/01/how-netflix-reverse-engineered-hollywood/282679/)
-* Many websites have information you may want to programaticaly read
+* Many websites have information you may want to programmatically read
 * In some cases this is against the terms of service for the website
 * Attempting to read too many pages too quickly can get your IP address blocked
 

--- a/03_GettingData/02_04_readingFromAPIs/index.md
+++ b/03_GettingData/02_04_readingFromAPIs/index.md
@@ -68,7 +68,7 @@ homeTL = GET("https://api.twitter.com/1.1/statuses/home_timeline.json", sig)
 
 ---
 
-## Converting the json object
+## Converting the JSON object
 
 
 ```r
@@ -88,7 +88,7 @@ json2[1,1:4]
 
 ---
 
-## How did I know what url to use?
+## How did I know what URL to use?
 
 
 <img class=center src=../../assets/img/03_ObtainingData/twitterurl.png height= 450/>
@@ -114,4 +114,4 @@ json2[1,1:4]
 * httr allows `GET`, `POST`, `PUT`, `DELETE` requests if you are authorized
 * You can authenticate with a user name or a password
 * Most modern APIs use something like oauth
-* httr works well with Facebook, Google, Twitter, Githb, etc. 
+* httr works well with Facebook, Google, Twitter, Github, etc. 

--- a/03_GettingData/02_05_readingFromOtherSources/index.md
+++ b/03_GettingData/02_05_readingFromOtherSources/index.md
@@ -58,9 +58,9 @@ exists is to Google "data storage mechanism R package"
 
 ## Examples of other database packages
 
-* RPostresSQL provides a DBI-compliant database connection from R. Tutorial-[https://code.google.com/p/rpostgresql/](https://code.google.com/p/rpostgresql/), help file-[http://cran.r-project.org/web/packages/RPostgreSQL/RPostgreSQL.pdf](http://cran.r-project.org/web/packages/RPostgreSQL/RPostgreSQL.pdf)
-* RODBC provides interfaces to multiple databases including PostgreQL, MySQL, Microsoft Access and SQLite. Tutorial - [http://cran.r-project.org/web/packages/RODBC/vignettes/RODBC.pdf](http://cran.r-project.org/web/packages/RODBC/vignettes/RODBC.pdf), help file - [http://cran.r-project.org/web/packages/RODBC/RODBC.pdf](http://cran.r-project.org/web/packages/RODBC/RODBC.pdf)
-* RMongo [http://cran.r-project.org/web/packages/RMongo/RMongo.pdf](http://cran.r-project.org/web/packages/RMongo/RMongo.pdf) (example of Rmongo [http://www.r-bloggers.com/r-and-mongodb/](http://www.r-bloggers.com/r-and-mongodb/)) and [rmongodb](http://cran.r-project.org/web/packages/rmongodb/rmongodb.pdf) provide interfaces to MongoDb. 
+* RPostgreSQL provides a DBI-compliant database connection from R. Tutorial-[https://code.google.com/p/rpostgresql/](https://code.google.com/p/rpostgresql/), help file-[http://cran.r-project.org/web/packages/RPostgreSQL/RPostgreSQL.pdf](http://cran.r-project.org/web/packages/RPostgreSQL/RPostgreSQL.pdf)
+* RODBC provides interfaces to multiple databases including PostgreSQL, MySQL, Microsoft Access and SQLite. Tutorial - [http://cran.r-project.org/web/packages/RODBC/vignettes/RODBC.pdf](http://cran.r-project.org/web/packages/RODBC/vignettes/RODBC.pdf), help file - [http://cran.r-project.org/web/packages/RODBC/RODBC.pdf](http://cran.r-project.org/web/packages/RODBC/RODBC.pdf)
+* RMongo [http://cran.r-project.org/web/packages/RMongo/RMongo.pdf](http://cran.r-project.org/web/packages/RMongo/RMongo.pdf) (example of RMongo [http://www.r-bloggers.com/r-and-mongodb/](http://www.r-bloggers.com/r-and-mongodb/)) and [rmongodb](http://cran.r-project.org/web/packages/rmongodb/rmongodb.pdf) provide interfaces to MongoDb. 
 
 
 ---

--- a/03_GettingData/03_01_subsettingAndSorting/index.md
+++ b/03_GettingData/03_01_subsettingAndSorting/index.md
@@ -74,7 +74,7 @@ X[1:2,"var2"]
 
 ---
 
-## Logicals ands and ors
+## Logical ands and ors
 
 
 ```r

--- a/03_GettingData/04_04_workingWithDates/index.md
+++ b/03_GettingData/04_04_workingWithDates/index.md
@@ -68,7 +68,7 @@ class(d2)
 ## Formatting dates
 
 `%d` = day as number (0-31), `%a` = abbreviated weekday,`%A` = unabbreviated weekday, `%m` = month (00-12), `%b` = abbreviated month,
-`%B` = unabbrevidated month, `%y` = 2 digit year, `%Y` = four digit year
+`%B` = unabbreviated month, `%y` = 2 digit year, `%Y` = four digit year
 
 
 ```r

--- a/03_GettingData/04_05_dataResources/index.md
+++ b/03_GettingData/04_05_dataResources/index.md
@@ -84,7 +84,7 @@ mode        : selfcontained # {standalone, draft}
 
 * [Stanford Large Network Data](http://snap.stanford.edu/data/)
 * [UCI Machine Learning](http://archive.ics.uci.edu/ml/)
-* [KDD Nugets Datasets](http://www.kdnuggets.com/datasets/index.html)
+* [KDD Nuggets Datasets](http://www.kdnuggets.com/datasets/index.html)
 * [CMU Statlib](http://lib.stat.cmu.edu/datasets/)
 * [Gene expression omnibus](http://www.ncbi.nlm.nih.gov/geo/)
 * [ArXiv Data](http://arxiv.org/help/bulk_data)

--- a/03_GettingData/announcements.md
+++ b/03_GettingData/announcements.md
@@ -13,7 +13,7 @@ of formats including JSON, XML, and flat files (.csv, .txt).
 The emphasis of this course is on creating tidy data sets that can be used in downstream analyses. Once you have mastered the material in this course you will be ready to learn about the techniques for exploring, analyzing, and summarizing data
 offered through our courses track or other Statistics, Data Science, or Machine Learning MOOCs. 
 
-Please see the course syllabus for information about the quizes, the project, due dates, and grading. Don't forget to say hi on the message boards. The community developed around these courses is one of the best places to learn and the best things about taking a MOOC!
+Please see the course syllabus for information about the quizzes, the project, due dates, and grading. Don't forget to say hi on the message boards. The community developed around these courses is one of the best places to learn and the best things about taking a MOOC!
 
 Jeff Leek and the Data Science Track Team
 
@@ -54,7 +54,7 @@ Jeff Leek and the Data Science Track Team
 
 Welcome to Week 4 of Obtaining Data! In this final week we will focus on peer grading of assignments. 
 
-Participating in peer grading is an amazing learning opportunity. It gives you a chance to learn things from your fellow students, pick up tips for explaning key ideas, and helping others to learn as well. We have focused our effort on making the rubric as objective and straightforward to implement as possible. If you have any issues please report them in the forums as described in the syllabus. 
+Participating in peer grading is an amazing learning opportunity. It gives you a chance to learn things from your fellow students, pick up tips for explaining key ideas, and helping others to learn as well. We have focused our effort on making the rubric as objective and straightforward to implement as possible. If you have any issues please report them in the forums as described in the syllabus. 
 
 Thanks again for all of your efforts in the course, we are in the last stretch. Good luck and have a great week!
 


### PR DESCRIPTION
 Fixes a typo on DataTypes slide 18 (missing parameter).

Fixes reference to JHU referencing handbook (dead link) in the syllabus.
