### PR TITLE
Update index.Rmd

### DIFF
--- a/08_PracticalMachineLearning/025combiningPredictors/index.Rmd
+++ b/08_PracticalMachineLearning/025combiningPredictors/index.Rmd
@@ -67,7 +67,7 @@ BellKor = Combination of 107 predictors
 Suppose we have 5 completely independent classifiers
 
 If accuracy is 70% for each:
-  * $10\times(0.7)^3(0.3)^2 + 5\times(0.7)^4(0.3)^2 + (0.7)^5$
+  * $10\times(0.7)^3(0.3)^2 + 5\times(0.7)^4(0.3) + (0.7)^5$
   * 83.7% majority vote accuracy
 
 With 101 independent classifiers


### PR DESCRIPTION
Formula of majority vote accuracy corrected. \* $10\times(0.7)^3(0.3)^2 + 5\times(0.7)^4(0.3) + (0.7)^5$ instead of \* $10\times(0.7)^3(0.3)^2 + 5\times(0.7)^4(0.3)"""^2""" + (0.7)^5$. Checked the new formula reflects the result given of 83.7% majority vote accuracy.
